### PR TITLE
Update submodules to be relative URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,18 +1,18 @@
 [submodule "gFTL"]
 	path = gFTL
-	url = https://github.com/Goddard-Fortran-Ecosystem/gFTL
+	url = ../gFTL.git
 [submodule "gFTL-shared"]
 	path = gFTL-shared
-	url = https://github.com/Goddard-Fortran-Ecosystem/gFTL-shared
+	url = ../gFTL-shared.git
 [submodule "fArgParse"]
 	path = fArgParse
-	url = https://github.com/Goddard-Fortran-Ecosystem/fArgParse
+	url = ../fArgParse.git
 [submodule "pFUnit"]
 	path = pFUnit
-	url = https://github.com/Goddard-Fortran-Ecosystem/pFUnit
+	url = ../pFUnit.git
 [submodule "yaFyaml"]
 	path = yaFyaml
-	url = https://github.com/Goddard-Fortran-Ecosystem/yaFyaml
+	url = ../yaFyaml.git
 [submodule "pFlogger"]
 	path = pFlogger
-	url = https://github.com/Goddard-Fortran-Ecosystem/pFlogger
+	url = ../pFlogger.git

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,17 +5,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2022-04-20
+
+## Changed
+
+- Updated git submodule URLs to relative URLs
+- Fixed typos in README
+
 ## [1.0.3] - 2022-04-19
 
 ## Changed
 
-- Minor bugfix update to pFUnit
+- Minor bugfix update to pFUnit (v4.2.7)
 
 ## [1.0.2] - 2022-04-19
 
 ## Changed
 
-- Update pFUnit to absorb critical bugfix.
+- Update pFUnit to absorb critical bugfix (v4.2.6)
 
 ## [1.0.1] - 2022-04-11
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # Goddard Fortran Ecosystem (GFE) SDK
 
-This repo is intendend to be a single fixture for the [Goddard Fortran Ecosystem](https://github.com/Goddard-Fortran-Ecosystem) libraries. This is useful for superprojects that depend on the GFE libraries. It is self-sufficient and prior installations of pFUnit/fArgParse/gFTL-share/gFTL are not required to run the unit tests. 
+This repo is intended to be a single fixture for the [Goddard Fortran Ecosystem](https://github.com/Goddard-Fortran-Ecosystem) libraries. This is useful for superprojects that depend on the GFE libraries. It is self-sufficient and prior installations of pFUnit/fArgParse/gFTL-share/gFTL are not required to run the unit tests. 
 
 ## Current versions
 
-| Package     | Version |
-| :------     | :------ |
-| gFTL        | v1.7.0  |
-| gFTL-shared | v1.4.1 |
-| fArgParse   | v1.2.0 |
+| Package     | Version    |
+| :------     | :------    |
+| gFTL        | v1.7.0     |
+| gFTL-shared | v1.4.1     |
+| fArgParse   | v1.2.0     |
 | yaFyaml     | v1.0-beta8 |
-| pFlogger    | v1.8.0 |
-| pFUnit      | v4.2.5 |
+| pFlogger    | v1.8.0     |
+| pFUnit      | v4.2.7     |
 
 ## Set up
 


### PR DESCRIPTION
This PR updates the submodules in this repo to be relative URLs. This was done by:
```
git submodule set-url gFTL ../gFTL.git
git submodule set-url gFTL-shared ../gFTL-shared.git
git submodule set-url fArgParse ../fArgParse.git
git submodule set-url pFUnit ../pFUnit.git
git submodule set-url yaFyaml ../yaFyaml.git
git submodule set-url pFlogger ../pFlogger.git
```

Also some minor edits to the readme.