### PR TITLE
Add release tarball uploader

### DIFF
--- a/.github/workflows/release-tarball.yml
+++ b/.github/workflows/release-tarball.yml
@@ -1,0 +1,31 @@
+name: Create Complete Release Tarball
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}
+
+      - name: Initialize submodules
+        run : |
+          cd ${GITHUB_WORKSPACE}/${{ github.event.repository.name }}-${{ github.event.release.tag_name }}
+          git submodule update --init
+
+      - name: Create tarball
+        run: |
+          tar --exclude-vcs -cf ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.tar ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}
+
+      - name: Upload tarball
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.tar -R ${{ github.repository_owner }}/${{ github.event.repository.name }}
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated git submodule URLs to relative URLs
 - Fixed typos in README
 
+## Added
+
+- Added GitHub Action to make a release tarball
+
 ## [1.0.3] - 2022-04-19
 
 ## Changed


### PR DESCRIPTION
This PR should add a GitHub Action to create a release tarball. In essence it does:

```
git clone https://github.com/Goddard-Fortran-Ecosystem/GFE.git GFE-vX.Y.Z
cd GFE-vX.Y.Z
git submodule update --init
cd ..
tar --exclude-vcs -cf GFE-vX.Y.Z.tar GFE-vX.Y.Z
gh release upload vX.Y.Z GFE-vX.Y.Z.tar -R Goddard-Fortran-Ecosystem/GFE
```

The interesting thing will be if we need to set something in the GFE settings to get this to work on that last step. Not sure. 
