### PR TITLE
WIP: Convert to use ExternalProject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,188 @@ cmake_policy(SET CMP0074 NEW)
 
 enable_testing()
 
-add_subdirectory(gFTL)
-add_subdirectory(gFTL-shared)
-add_subdirectory(fArgParse)
-add_subdirectory(pFUnit)
-add_subdirectory(yaFyaml)
-add_subdirectory(pFlogger)
+#add_subdirectory(gFTL)
+#add_subdirectory(gFTL-shared)
+#add_subdirectory(fArgParse)
+#add_subdirectory(pFUnit)
+#add_subdirectory(yaFyaml)
+#add_subdirectory(pFlogger)
+
+include(ExternalProject)
+
+ExternalProject_Add(gFTL
+  SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/gFTL
+
+  CMAKE_ARGS
+     -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+     -DCMAKE_PREFIX_PATH:PATH=${CMAKE_INSTALL_PREFIX}
+
+  BUILD_COMMAND $(MAKE)
+
+  INSTALL_COMMAND $(MAKE) install
+  INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
+
+  #LOG_DIR               ${CMAKE_INSTALL_PREFIX}/logs/gFTL
+  #LOG_CONFIGURE         TRUE
+  #LOG_BUILD             TRUE
+  #LOG_INSTALL           TRUE
+  #LOG_MERGED_STDOUTERR  TRUE
+  #LOG_OUTPUT_ON_FAILURE TRUE
+  )
+
+ExternalProject_Add(gFTL-shared
+  SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/gFTL-shared
+
+  CMAKE_ARGS
+     -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+     -DCMAKE_PREFIX_PATH:PATH=${CMAKE_INSTALL_PREFIX}
+
+  BUILD_COMMAND $(MAKE)
+
+  INSTALL_COMMAND $(MAKE) install
+  INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
+
+  #LOG_DIR               ${CMAKE_INSTALL_PREFIX}/logs/gFTL-shared
+  #LOG_CONFIGURE         TRUE
+  #LOG_BUILD             TRUE
+  #LOG_INSTALL           TRUE
+  #LOG_MERGED_STDOUTERR  TRUE
+  #LOG_OUTPUT_ON_FAILURE TRUE
+
+  DEPENDS gFTL
+  )
+
+ExternalProject_Add(fArgParse
+  SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/fArgParse
+
+  CMAKE_ARGS
+     -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+     -DCMAKE_PREFIX_PATH:PATH=${CMAKE_INSTALL_PREFIX}
+
+  BUILD_COMMAND $(MAKE)
+
+  INSTALL_COMMAND $(MAKE) install
+  INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
+
+  #LOG_DIR               ${CMAKE_INSTALL_PREFIX}/logs/fArgParse
+  #LOG_CONFIGURE         TRUE
+  #LOG_BUILD             TRUE
+  #LOG_INSTALL           TRUE
+  #LOG_MERGED_STDOUTERR  TRUE
+  #LOG_OUTPUT_ON_FAILURE TRUE
+
+  DEPENDS gFTL
+  DEPENDS gFTL-shared
+  )
+
+ExternalProject_Add(pFUnit
+  SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/pFUnit
+
+  CMAKE_ARGS
+     -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+     -DCMAKE_PREFIX_PATH:PATH=${CMAKE_INSTALL_PREFIX}
+     -DSKIP_OPENMP=${SKIP_OPENMP}
+
+  BUILD_COMMAND $(MAKE)
+
+  INSTALL_COMMAND $(MAKE) install
+  INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
+
+  #LOG_DIR               ${CMAKE_INSTALL_PREFIX}/logs/pFUnit
+  #LOG_CONFIGURE         TRUE
+  #LOG_BUILD             TRUE
+  #LOG_INSTALL           TRUE
+  #LOG_MERGED_STDOUTERR  TRUE
+  #LOG_OUTPUT_ON_FAILURE TRUE
+
+  DEPENDS gFTL
+  DEPENDS gFTL-shared
+  DEPENDS fArgParse
+  )
+
+ExternalProject_Add(yaFyaml
+  SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/yaFyaml
+
+  CMAKE_ARGS
+     -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+     -DCMAKE_PREFIX_PATH:PATH=${CMAKE_INSTALL_PREFIX}
+
+  BUILD_COMMAND $(MAKE)
+
+  INSTALL_COMMAND $(MAKE) install
+  INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
+
+  #LOG_DIR               ${CMAKE_INSTALL_PREFIX}/logs/yaFyaml
+  #LOG_CONFIGURE         TRUE
+  #LOG_BUILD             TRUE
+  #LOG_INSTALL           TRUE
+  #LOG_MERGED_STDOUTERR  TRUE
+  #LOG_OUTPUT_ON_FAILURE TRUE
+
+  DEPENDS gFTL
+  DEPENDS gFTL-shared
+  )
+
+ExternalProject_Add(pFlogger
+  SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/pFlogger
+
+  CMAKE_ARGS
+     -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+     -DCMAKE_PREFIX_PATH:PATH=${CMAKE_INSTALL_PREFIX}
+
+  BUILD_COMMAND $(MAKE)
+
+  INSTALL_COMMAND $(MAKE) install
+  INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
+
+  #LOG_DIR               ${CMAKE_INSTALL_PREFIX}/logs/pFlogger
+  #LOG_CONFIGURE         TRUE
+  #LOG_BUILD             TRUE
+  #LOG_INSTALL           TRUE
+  #LOG_MERGED_STDOUTERR  TRUE
+  #LOG_OUTPUT_ON_FAILURE TRUE
+
+  DEPENDS gFTL
+  DEPENDS gFTL-shared
+  DEPENDS yaFyaml
+  )
+
+ExternalProject_Add_Step(gFTL tests
+  COMMAND           $(MAKE) tests
+  WORKING_DIRECTORY <BINARY_DIR>
+  COMMENT           "Building gFTL tests"
+  EXCLUDE_FROM_MAIN TRUE
+)
+ExternalProject_Add_StepTargets(gFTL tests)
+
+ExternalProject_Add_Step(pFUnit tests
+  COMMAND           $(MAKE) tests
+  WORKING_DIRECTORY <BINARY_DIR>
+  COMMENT           "Building pFUnit tests"
+  EXCLUDE_FROM_MAIN TRUE
+)
+ExternalProject_Add_StepTargets(pFUnit tests)
+
+ExternalProject_Add_Step(pFlogger tests
+  COMMAND           $(MAKE) tests
+  WORKING_DIRECTORY <BINARY_DIR>
+  COMMENT           "Building pFlogger tests"
+  EXCLUDE_FROM_MAIN TRUE
+)
+ExternalProject_Add_StepTargets(pFlogger tests)
+
+ExternalProject_Add_Step(fArgParse tests
+  COMMAND           $(MAKE) tests
+  WORKING_DIRECTORY <BINARY_DIR>
+  COMMENT           "Building fArgParse tests"
+  EXCLUDE_FROM_MAIN TRUE
+)
+ExternalProject_Add_StepTargets(fArgParse tests)
+
+ExternalProject_Add_Step(yaFyaml tests
+  COMMAND           $(MAKE) tests
+  WORKING_DIRECTORY <BINARY_DIR>
+  COMMENT           "Building yaFyaml tests"
+  EXCLUDE_FROM_MAIN TRUE
+)
+ExternalProject_Add_StepTargets(yaFyaml tests)


### PR DESCRIPTION
This is a draft PR to capture the experiments with `ExternalProject_Add` in GFE by myself and @tclune. 

At the moment, this seems to *build* GFE just fine. The issue at the moment is we aren't sure how to do the `tests` bit.

For example, in current GFE you do:

1. `mkdir build && cd build`
2. `cmake .. -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_PREFIX_PATH=../install -DSKIP_OPENMP=ON`
3. `make install`
4. `cmake .. -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_PREFIX_PATH=../install -DSKIP_OPENMP=ON`
5. `make tests`

The second `cmake` is that the first time around, there was no pFUnit, so no tests were created to build by CMake. Now it sees the installed pFUnit and can make the tests.

Now, with the `ExternalProject_Add` version you have to do:

1. `mkdir build && cd build`
2. `cmake .. -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_PREFIX_PATH=../install -DSKIP_OPENMP=ON`
3. `make` (note *NO* install)
4. `rm -rf *` (*the build directory must be removed*)
5. `cmake .. -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_PREFIX_PATH=../install -DSKIP_OPENMP=ON`
6. `make gFTL-tests`
7. `make yaFyaml-tests`
8. ...

So you have to run each set of tests individually.

The questions going forward:

1. Can you get `ExternalProject_Add` to somehow "re-run" CMake for you?
2. Can we make a new custom `tests` target that when we do `make tests` will run the tests for each subproject?
