### PR TITLE
Update CI to use Intel LLVM

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           ${FC} --version
           cmake --version
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -54,6 +55,7 @@ jobs:
       - name: Set all directories as git safe
         run: |
           git config --global --add safe.directory '*'
+
       - name: Cache MPI
         id: cache-mpi
         uses: actions/cache@v3
@@ -61,25 +63,17 @@ jobs:
           path: ~/local/openmpi
           key: mpi-${{ runner.os }}-${{ matrix.os }}-${{ matrix.compiler }}
 
-      # For some reason the GitHub Actions macOS image seems to have triggered
-      # a 7-year old bug: https://github.com/Homebrew/legacy-homebrew/issues/19046
-      # For now we only fix if MPI isn't cached already as it only seems important
-      # for OpenMPI
-
-      - name: Fix gmp and mpfr on macOS if MPI isn't cached
-        if: steps.cache-mpi.outputs.cache-hit != 'true' && matrix.os == 'macos-10.15'
-        run: |
-          brew reinstall --build-from-source gmp mpfr
-
       - name: Build MPI
         if: steps.cache-mpi.outputs.cache-hit != 'true'
         run: |
           sh ${GITHUB_WORKSPACE}/tools/ci-install-mpi.sh openmpi 4.1.4
+
       - name: Set MPI Environment
         run: |
           echo "${HOME}/local/openmpi/bin" >> $GITHUB_PATH
           echo "LD_LIBRARY_PATH=${HOME}/local/openmpi/lib" >> $GITHUB_ENV
           echo "DYLD_LIBRARY_PATH=${HOME}/local/openmpi/lib" >> $GITHUB_ENV
+
       - name: MPI Versions
         run: |
           ${FC} --version
@@ -98,7 +92,7 @@ jobs:
           cd build
           make -j$(nproc 2>/dev/null || sysctl -n hw.logicalcpu) tests
       - name: Archive log files on failure
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: logfiles
@@ -109,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      FC: ifort
+      FC: ifx
       CC: icx
 
     name: Intel Fortran
@@ -119,17 +113,29 @@ jobs:
         with:
           fetch-depth: 1
           submodules: true
-      - name: Install Intel compilers
+
+      - name: Setup Intel oneAPI repository
         run: |
-          cd /tmp
           wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
           sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
-          rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
           sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
-          sudo apt install --no-install-recommends intel-oneapi-compiler-fortran intel-oneapi-mpi \
-            intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-mpi-devel
+          sudo apt-get update
+
+      - name: Install Intel oneAPI compilers
+        timeout-minutes: 5
+        run: sudo apt-get install intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp
+
+      # optional
+      - name: Install Intel MPI
+        timeout-minutes: 5
+        run: sudo apt-get install intel-oneapi-mpi intel-oneapi-mpi-devel
+
+      - name: Setup Intel oneAPI environment
+        run: |
           source /opt/intel/oneapi/setvars.sh
           printenv >> $GITHUB_ENV
+          printenv | grep intel
+
       - name: Versions
         run: |
           ${FC} --version
@@ -148,7 +154,7 @@ jobs:
           cd build
           make -j$(nproc 2>/dev/null || sysctl -n hw.logicalcpu) tests
       - name: Archive log files on failure
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: logfiles

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update CI to use Intel LLVM
+
 ## [1.12.0] - 2023-11-29
+
+### Changed
 
 - Updated submodules for all repos. (See README)
 


### PR DESCRIPTION
Changes to Intel's repos mean Intel Fortran Classic is just not that gettable anymore. So we move to use `ifx`.