### PR TITLE
Update CI to NVHPC 24.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -170,7 +170,7 @@ jobs:
 
   Nvidia:
     runs-on: ubuntu-20.04
-    container: nvcr.io/nvidia/nvhpc:24.1-devel-cuda12.3-ubuntu22.04
+    container: nvcr.io/nvidia/nvhpc:24.3-devel-cuda12.3-ubuntu22.04
     env:
       FC: nvfortran
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Move to NVHPC 24.3 in CI
+
 ## [1.14.0] - 2024-03-20
 
 ### Changed


### PR DESCRIPTION
This updates the CI to use NVHPC 24.3.

Mainly doing this as a first test while I try and install on bucy.