### PR TITLE
Update to pFlogger v1.14.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 project (GFE
-  VERSION 1.14.0
+  VERSION 1.15.0
   LANGUAGES Fortran
 )
 cmake_policy(SET CMP0074 NEW)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.0] - 2024-03-26
+
+### Changed
+
+- Update pFlogger to v1.14.0
+  - Added `-quiet` flag for NAG Fortran
+  - Workaround additional polymorphic assignment bug in gfortran 13.2 (in build_locks)
+
 ## [1.14.0] - 2024-03-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repo is intended to be a single fixture for the [Goddard Fortran Ecosystem]
 | fArgParse   | v1.7.0     |
 | pFUnit      | v4.9.0     |
 | yaFyaml     | v1.3.0     |
-| pFlogger    | v1.13.2    |
+| pFlogger    | v1.14.0    |
 
 ## Set up
 


### PR DESCRIPTION
This PR updates pFlogger to v1.14.0 and moves GFE to v1.15.0.

This has what we hope is the final GCC 13 workaround! 🎉 