### PR TITLE
CI: Drop macos-13, add macos-15, add gfortran-15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-14]
-        compiler: [gfortran-12, gfortran-13, gfortran-14]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
+        compiler: [gfortran-12, gfortran-13, gfortran-14, gfortran-15]
         # gfortran-10 and -11 are only on ubuntu-22.04
-        # gfortran-13 and -14 are not on ubuntu-22.04
+        # gfortran-13 and -14 and -15 are not on ubuntu-22.04
+        # gfortran-15 is only on macos
         include:
           - os: ubuntu-22.04
             compiler: gfortran-10
@@ -29,6 +30,10 @@ jobs:
             compiler: gfortran-13
           - os: ubuntu-22.04
             compiler: gfortran-14
+          - os: ubuntu-22.04
+            compiler: gfortran-15
+          - os: ubuntu-24.04
+            compiler: gfortran-15
 
       # fail-fast if set to 'true' here is good for production, but when
       # debugging, set to 'false'. fail-fast means if *any* ci test in the matrix fails

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.24)
 project (GFE
   VERSION 1.19.0
   LANGUAGES Fortran

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove `macos-13` from CI, add `macos-15`
+- Add `gfortran-15` to macOS CI
+
 ## [1.19.0] - 2025-02-11
 
 ### Changed

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove `macos-13` from CI, add `macos-15`
 - Add `gfortran-15` to macOS CI
+- Update CMake minimum version to 3.24
 
 ## [1.19.0] - 2025-02-11
 


### PR DESCRIPTION
As GitHub will soon drop support for macOS 13, we are updating our CI workflows to use macOS 15. Additionally, we are adding support for gfortran-15 to ensure compatibility with the latest Fortran compiler.