### PR TITLE
Maintain CI workflow configuration

### DIFF
--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -19,4 +19,3 @@ jobs:
             used. If your change is very trivial not applicable for a
             changelog entry, add a 'skip changelog' label to the pull
             request to skip the changelog enforcer.
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,8 @@ on:
       - "**.MD"
       - "LICENCE"
       - "COPYRIGHT"
-  # This is a weekly run to try and keep the MPI caches ... cached
-  schedule:
-    - cron: '00 13 * * 1'
+  # Allow the scheduled workflow to reuse this test matrix.
+  workflow_call:
   # Allow us to trigger it manually
   workflow_dispatch:
 
@@ -72,7 +71,7 @@ jobs:
           cmake --version
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
@@ -83,7 +82,7 @@ jobs:
 
       - name: Cache MPI
         id: cache-mpi
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/local/openmpi
           key: mpi-${{ matrix.os }}-${{ matrix.compiler }}-openmpi-5.0.10
@@ -142,7 +141,7 @@ jobs:
     name: Intel Fortran
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
@@ -242,7 +241,7 @@ jobs:
           docker system prune -af || true
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
@@ -330,7 +329,7 @@ jobs:
           cmake --version
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
@@ -366,4 +365,3 @@ jobs:
           name: logfiles-Flang
           path: |
             build/**/*.log
-

--- a/.github/workflows/readme-enforcer.yml
+++ b/.github/workflows/readme-enforcer.yml
@@ -18,4 +18,3 @@ jobs:
             If your change is very trivial not applicable for a
             README entry, add a 'skip readme' label to the pull
             request to skip the README enforcer.
-

--- a/.github/workflows/release-tarball.yml
+++ b/.github/workflows/release-tarball.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}
 
@@ -28,4 +28,3 @@ jobs:
           gh release upload ${{ github.event.release.tag_name }} ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.tar -R ${{ github.repository_owner }}/${{ github.event.repository.name }}
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,11 @@
+name: Scheduled CI
+
+on:
+  # Run weekly to try and keep the MPI caches cached.
+  schedule:
+    - cron: '00 13 * * 1'
+  workflow_dispatch:
+
+jobs:
+  ci:
+    uses: ./.github/workflows/main.yml

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updates for new flang docker image
+- Update CI workflows
+  - Separate scheduled runs from pull-request CI
+  - Update GitHub Actions to current major versions
 
 ## [1.28.0] - 2026-05-28
 
@@ -435,4 +438,3 @@ Initial release
 | yaFyaml     | v1.0-beta8 |
 | pFlogger    | v1.8.0 |
 | pFUnit      | v4.2.5 |
-


### PR DESCRIPTION
## Summary
- Separate scheduled CI from pull-request CI to prevent inactivity disabling PR tests
- Update GitHub Actions to major versions
- Keep Intel oneAPI/MPI versions at 2025.3/2021.17
- Add the required changelog entry

## Validation
- Parsed all workflow YAML files successfully
- `git diff --check` passes